### PR TITLE
Added showsBackgroundLocationIndicator

### DIFF
--- a/ios/Classes/SwiftBackgroundLocationPlugin.swift
+++ b/ios/Classes/SwiftBackgroundLocationPlugin.swift
@@ -20,6 +20,9 @@ public class SwiftBackgroundLocationPlugin: NSObject, FlutterPlugin, CLLocationM
         SwiftBackgroundLocationPlugin.locationManager?.requestAlwaysAuthorization()
 
         SwiftBackgroundLocationPlugin.locationManager?.allowsBackgroundLocationUpdates = true
+        if #available(iOS 11.0, *) {
+            SwiftBackgroundLocationPlugin.locationManager?.showsBackgroundLocationIndicator = true;
+        }
         SwiftBackgroundLocationPlugin.locationManager?.pausesLocationUpdatesAutomatically = false
 
         SwiftBackgroundLocationPlugin.channel?.invokeMethod("location", arguments: "method")

--- a/lib/background_location.dart
+++ b/lib/background_location.dart
@@ -41,17 +41,15 @@ class BackgroundLocation {
 
   /// Ask the user for location permissions
   static getPermissions({Function onGranted, Function onDenied}) async {
-    await PermissionHandler()
-        .requestPermissions([PermissionGroup.locationAlways]);
-    PermissionStatus permission = await PermissionHandler()
-        .checkPermissionStatus(PermissionGroup.locationAlways);
-    if (permission == PermissionStatus.granted) {
+    await Permission.locationWhenInUse.request();
+    if (await Permission.locationWhenInUse.isGranted) {
       if (onGranted != null) {
         onGranted();
       }
-    } else if (permission == PermissionStatus.denied ||
-        permission == PermissionStatus.restricted ||
-        permission == PermissionStatus.unknown) {
+    } else if (await Permission.locationWhenInUse.isDenied ||
+        await Permission.locationWhenInUse.isPermanentlyDenied ||
+        await Permission.locationWhenInUse.isRestricted ||
+        await Permission.locationWhenInUse.isUndetermined) {
       if (onDenied != null) {
         onDenied();
       }
@@ -60,8 +58,7 @@ class BackgroundLocation {
 
   /// Check what the current permissions status is
   static Future<PermissionStatus> checkPermissions() async {
-    PermissionStatus permission = await PermissionHandler()
-        .checkPermissionStatus(PermissionGroup.locationAlways);
+    PermissionStatus permission = await Permission.locationWhenInUse.status;
     return permission;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler: ^4.0.0
+  permission_handler: ^5.0.1+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Resolves #29 .

On iOS 13 I have noted that until location permission 'always' is set, location updates are not triggered. The location permission first prompts for 'when in use' and will only prompt for 'always' at a later undetermined time. Until this occurs no location data is available.

According to [this](https://developer.apple.com/documentation/corelocation/choosing_the_location_services_authorization_to_request) we should be able to get locations with only 'when in use' even in background but it doesn't appear to occur in our testing unless we force 'always' under settings  manually or wait some arbitrary time until the iOS prompts for as much.   

According to this [here](https://stackoverflow.com/questions/58184876/what-conditions-make-ios-13-to-ask-user-to-grant-always-location-access), if we add `showsBackgroundLocationIndicator = true` we can start streaming locations even in background with only the 'when in use'. 

This PR adds

```
        if #available(iOS 11.0, *) {
            SwiftBackgroundLocationPlugin.locationManager?.showsBackgroundLocationIndicator = true;
        }
```

Updated permission_handler plugin to 5.0.0+1