### PR TITLE
Fix invalid cast error

### DIFF
--- a/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationPlugin.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationPlugin.kt
@@ -98,7 +98,7 @@ class BackgroundLocationPlugin() : MethodCallHandler, PluginRegistry.RequestPerm
                 result.success(0);
             }
             call.method == "set_configuration" -> {
-                val timeInterval: Long? = call.argument("interval");
+                val timeInterval: Long? = call.argument<String>("interval")?.toLongOrNull();
                 if (timeInterval != null) LocationUpdatesService.UPDATE_INTERVAL_IN_MILLISECONDS = timeInterval
 
                 result.success(0);

--- a/lib/background_location.dart
+++ b/lib/background_location.dart
@@ -33,7 +33,7 @@ class BackgroundLocation {
     }
   }
 
-  static setAndroidConfiguration({int interval}) async {
+  static setAndroidConfiguration(int interval) async {
     if (Platform.isAndroid) {
       return await _channel.invokeMethod("set_configuration", <String, dynamic>{
         "interval": interval.toString(),


### PR DESCRIPTION
Calling setAndroidConfiguration was passing a string to the  "set_configuration" methodcall in BackgroundLocationPlugin.kt causing an invalid cast error 

The named parameter has also been removed for compatibility with the example