### PR TITLE
Fix stuck on await start/stop location

### DIFF
--- a/ios/Classes/SwiftBackgroundLocationPlugin.swift
+++ b/ios/Classes/SwiftBackgroundLocationPlugin.swift
@@ -39,6 +39,7 @@ public class SwiftBackgroundLocationPlugin: NSObject, FlutterPlugin, CLLocationM
             SwiftBackgroundLocationPlugin.channel?.invokeMethod("location", arguments: "stop_location_service")
             SwiftBackgroundLocationPlugin.locationManager?.stopUpdatingLocation()
         }
+        result(true)
     }
     
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {


### PR DESCRIPTION
I noticed that even the example project wasn't working properly on iOS. I figured out that it got stuck on the `await BackgroundLocation.startLocationService(distanceFilter: 20);` because it never returned something.

I fixed it here by just returning a boolean inside the native iOS code. It's probably not the best solution but it works for me on my two iOS devices.

I like to know what you think of this fix and if you can reproduce the same issue.