### PR TITLE
add fallback for LocationManager in case google api is not available

### DIFF
--- a/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
@@ -1,15 +1,17 @@
 package com.almoullim.background_location
 
 import android.app.*
+import android.location.*
+import android.location.LocationListener
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.location.Location
 import android.os.*
 import androidx.core.app.NotificationCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.android.gms.location.*
+import com.google.android.gms.common.*
 
 
 class LocationUpdatesService : Service() {
@@ -28,8 +30,11 @@ class LocationUpdatesService : Service() {
     private var mNotificationManager: NotificationManager? = null
     private var mLocationRequest: LocationRequest? = null
     private var mFusedLocationClient: FusedLocationProviderClient? = null
-    private var mLocationCallback: LocationCallback? = null
+    private var mLocationManager: LocationManager? = null
+    private var mFusedLocationCallback: LocationCallback? = null
+    private var mLocationManagerCallback: LocationListener? = null
     private var mLocation: Location? = null
+    private var isGoogleApiAvailable: Boolean = false
     private var isStarted: Boolean = false
 
     companion object {
@@ -81,13 +86,31 @@ class LocationUpdatesService : Service() {
     private var mServiceHandler: Handler? = null
 
     override fun onCreate() {
+        var googleAPIAvailability = GoogleApiAvailability.getInstance()
+            .isGooglePlayServicesAvailable(getApplicationContext())
+        if (googleAPIAvailability != ConnectionResult.SUCCESS) {
+            isGoogleApiAvailable = false
+        } else {
+            isGoogleApiAvailable = true
+        }
 
-        mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
+        if (isGoogleApiAvailable) {
+            mFusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
+            
+            mFusedLocationCallback = object : LocationCallback() {
+                override fun onLocationResult(locationResult: LocationResult?) {
+                    super.onLocationResult(locationResult)
+                    onNewLocation(locationResult!!.lastLocation)
+                }
+            }
+        } else {
+            mLocationManager = getSystemService(LOCATION_SERVICE) as LocationManager?
 
-        mLocationCallback = object : LocationCallback() {
-            override fun onLocationResult(locationResult: LocationResult?) {
-                super.onLocationResult(locationResult)
-                onNewLocation(locationResult!!.lastLocation)
+            mLocationManagerCallback = object : LocationListener {
+                override fun onLocationChanged(location: Location) {
+                    println(location.toString())
+                    onNewLocation(location)
+                }
             }
         }
 
@@ -122,8 +145,12 @@ class LocationUpdatesService : Service() {
     fun requestLocationUpdates() {
         Utils.setRequestingLocationUpdates(this, true)
         try {
-            mFusedLocationClient!!.requestLocationUpdates(mLocationRequest,
-                    mLocationCallback!!, Looper.myLooper())
+            if (isGoogleApiAvailable) {
+                mFusedLocationClient!!.requestLocationUpdates(mLocationRequest,
+                    mFusedLocationCallback!!, Looper.myLooper())
+            } else {
+                mLocationManager?.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0L, 0f, mLocationManagerCallback!!)
+            }
         } catch (unlikely: SecurityException) {
             Utils.setRequestingLocationUpdates(this, false)
         }
@@ -147,13 +174,17 @@ class LocationUpdatesService : Service() {
 
     private fun getLastLocation() {
         try {
-            mFusedLocationClient!!.lastLocation
-                    .addOnCompleteListener { task ->
-                        if (task.isSuccessful && task.result != null) {
-                            mLocation = task.result
-                        } else {
+            if(isGoogleApiAvailable) {
+                mFusedLocationClient!!.lastLocation
+                        .addOnCompleteListener { task ->
+                            if (task.isSuccessful && task.result != null) {
+                                mLocation = task.result
+                            } else {
+                            }
                         }
-                    }
+            } else {
+                mLocation = mLocationManager!!.getLastKnownLocation(LocationManager.GPS_PROVIDER);
+            }
         } catch (unlikely: SecurityException) {
         }
 
@@ -187,7 +218,12 @@ class LocationUpdatesService : Service() {
         isStarted = false
         unregisterReceiver(broadcastReceiver)
         try {
-            mFusedLocationClient!!.removeLocationUpdates(mLocationCallback!!)
+            if (isGoogleApiAvailable) {
+                mFusedLocationClient!!.removeLocationUpdates(mFusedLocationCallback!!)
+            } else {
+                mLocationManager!!.removeUpdates(mLocationManagerCallback!!)
+            }
+
             Utils.setRequestingLocationUpdates(this, false)
             mNotificationManager!!.cancel(NOTIFICATION_ID)
         } catch (unlikely: SecurityException) {


### PR DESCRIPTION
… fixes #69 and fixes #14

If FusedLocationProvider is not available because of missing google play services on the device, this change will cause the plugin to fall back onto LocationManager.

This was my first time writing kotlin code, so it might need improving and it definitely needs more testing.
Also i was only able to test this on a device without google play services.