### PR TITLE
Fixed channel exception, Update SwiftBackgroundLocationPlugin.swift

### DIFF
--- a/ios/Classes/SwiftBackgroundLocationPlugin.swift
+++ b/ios/Classes/SwiftBackgroundLocationPlugin.swift
@@ -9,7 +9,7 @@ public class SwiftBackgroundLocationPlugin: NSObject, FlutterPlugin, CLLocationM
     public static func register(with registrar: FlutterPluginRegistrar) {
         let instance = SwiftBackgroundLocationPlugin()
         
-        SwiftBackgroundLocationPlugin.channel = FlutterMethodChannel(name: "almoullim.com/background_location", binaryMessenger: registrar.messenger())
+        SwiftBackgroundLocationPlugin.channel = FlutterMethodChannel(name: "com.almoullim.background_location/methods", binaryMessenger: registrar.messenger())
         registrar.addMethodCallDelegate(instance, channel: SwiftBackgroundLocationPlugin.channel!)
         SwiftBackgroundLocationPlugin.channel?.setMethodCallHandler(instance.handle)
     }


### PR DESCRIPTION
Fixed:  Unhandled Exception: MissingPluginException(No implementation found for method start_location_service on channel com.almoullim.background_location/methods)