### PR TITLE
Fixed unresolved references

### DIFF
--- a/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationPlugin.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationPlugin.kt
@@ -1,29 +1,10 @@
 package com.almoullim.background_location
 
-import android.Manifest
-import android.app.Activity
-import android.content.*
-import android.content.pm.PackageManager
-import android.location.Location
-import android.os.IBinder
-import android.util.Log
-import android.widget.Toast
-import androidx.core.app.ActivityCompat
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
-import io.flutter.plugin.common.BinaryMessenger
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
-import io.flutter.plugin.common.PluginRegistry.NewIntentListener
-
-
-
 
 
 class BackgroundLocationPlugin : FlutterPlugin, ActivityAware {

--- a/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
@@ -101,13 +101,11 @@ class BackgroundLocationService: MethodChannel.MethodCallHandler, PluginRegistry
         }
     }
 
-    private fun startLocationService(distanceFilter: Double?): Int{
+    private fun startLocationService(distanceFilter: Double?, forceLocationManager : Boolean?): Int{
         LocalBroadcastManager.getInstance(context!!).registerReceiver(receiver!!,
                 IntentFilter(LocationUpdatesService.ACTION_BROADCAST))
         if (!bound) {
             val intent = Intent(context, LocationUpdatesService::class.java)
-            val distanceFilter : Double? = call.argument("distance_filter")
-            val forceLocationManager : Boolean? = call.argument("forceAndroidLocationManager")
             intent.putExtra("distance_filter", distanceFilter)
             intent.putExtra("force_location_manager", forceLocationManager)
             context!!.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
@@ -149,7 +147,7 @@ class BackgroundLocationService: MethodChannel.MethodCallHandler, PluginRegistry
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
         when (call.method) {
             "stop_location_service" -> result.success(stopLocationService())
-            "start_location_service" -> result.success(startLocationService(call.argument("distance_filter")))
+            "start_location_service" -> result.success(startLocationService(call.argument("distance_filter"), call.argument("force_location_manager")))
             "set_android_notification" -> result.success(setAndroidNotification(call.argument("title"),call.argument("message"),call.argument("icon")))
             "set_configuration" -> result.success(setConfiguration(call.argument<String>("interval")?.toLongOrNull()))
             else -> result.notImplemented()

--- a/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
@@ -12,14 +12,14 @@ import android.os.*
 import androidx.core.app.NotificationCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.android.gms.location.*
+import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.common.*
-
 
 class LocationUpdatesService : Service() {
 
-    private var forceLocationManager: Boolean = false;
+    private var forceLocationManager: Boolean = false
 
-    override fun onBind(intent: Intent?): IBinder? {
+    override fun onBind(intent: Intent?): IBinder {
         val distanceFilter = intent?.getDoubleExtra("distance_filter", 0.0)
         if (intent != null) {
             forceLocationManager = intent.getBooleanExtra("force_location_manager", false)
@@ -48,18 +48,18 @@ class LocationUpdatesService : Service() {
         var NOTIFICATION_MESSAGE = "Background service is running"
         var NOTIFICATION_ICON = "@mipmap/ic_launcher"
 
-        private val PACKAGE_NAME = "com.google.android.gms.location.sample.locationupdatesforegroundservice"
+        private const val PACKAGE_NAME = "com.google.android.gms.location.sample.locationupdatesforegroundservice"
         private val TAG = LocationUpdatesService::class.java.simpleName
-        private val CHANNEL_ID = "channel_01"
-        internal val ACTION_BROADCAST = "$PACKAGE_NAME.broadcast"
-        internal val EXTRA_LOCATION = "$PACKAGE_NAME.location"
-        private val EXTRA_STARTED_FROM_NOTIFICATION = "$PACKAGE_NAME.started_from_notification"
+        private const val CHANNEL_ID = "channel_01"
+        internal const val ACTION_BROADCAST = "$PACKAGE_NAME.broadcast"
+        internal const val EXTRA_LOCATION = "$PACKAGE_NAME.location"
+        private const val EXTRA_STARTED_FROM_NOTIFICATION = "$PACKAGE_NAME.started_from_notification"
         var UPDATE_INTERVAL_IN_MILLISECONDS: Long = 1000
         private val FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS = UPDATE_INTERVAL_IN_MILLISECONDS / 2
-        private val NOTIFICATION_ID = 12345678
+        private const val NOTIFICATION_ID = 12345678
         private lateinit var broadcastReceiver: BroadcastReceiver
 
-        private val STOP_SERVICE = "stop_service"
+        private const val STOP_SERVICE = "stop_service"
     }
 
 
@@ -98,8 +98,8 @@ class LocationUpdatesService : Service() {
     private var mServiceHandler: Handler? = null
 
     override fun onCreate() {
-        var googleAPIAvailability = GoogleApiAvailability.getInstance()
-            .isGooglePlayServicesAvailable(getApplicationContext())
+        val googleAPIAvailability = GoogleApiAvailability.getInstance()
+            .isGooglePlayServicesAvailable(applicationContext)
         
         isGoogleApiAvailable = googleAPIAvailability == ConnectionResult.SUCCESS
         
@@ -116,11 +116,9 @@ class LocationUpdatesService : Service() {
         } else {
             mLocationManager = getSystemService(LOCATION_SERVICE) as LocationManager?
 
-            mLocationManagerCallback = object : LocationListener {
-                override fun onLocationChanged(location: Location) {
-                    println(location.toString())
-                    onNewLocation(location)
-                }
+            mLocationManagerCallback = LocationListener { location ->
+                println(location.toString())
+                onNewLocation(location)
             }
         }
 
@@ -191,15 +189,13 @@ class LocationUpdatesService : Service() {
                         .addOnCompleteListener { task ->
                             if (task.isSuccessful && task.result != null) {
                                 mLocation = task.result
-                            } else {
                             }
                         }
             } else {
-                mLocation = mLocationManager!!.getLastKnownLocation(LocationManager.GPS_PROVIDER);
+                mLocation = mLocationManager!!.getLastKnownLocation(LocationManager.GPS_PROVIDER)
             }
         } catch (unlikely: SecurityException) {
         }
-
     }
 
     private fun onNewLocation(location: Location) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   boolean_selector:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR fixes:
- Unresolved reference to `MethodCall` instance in `startLocationService` function
- Unresolved reference to `LocationRequest` in `LocationUpdatesService.kt`  when building with Android SDK 31
- Fixes wrong reference to `call.argument("forceAndroidLocationManager")` instead of proper `call.argument("force_location_manager")`