### PR TITLE
Android: Update fastest interval during config change

### DIFF
--- a/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
@@ -139,7 +139,10 @@ class BackgroundLocationService: MethodChannel.MethodCallHandler, PluginRegistry
     }
 
     private fun setConfiguration(timeInterval: Long?):Int {
-        if (timeInterval != null) LocationUpdatesService.UPDATE_INTERVAL_IN_MILLISECONDS = timeInterval
+        if (timeInterval != null) {
+            LocationUpdatesService.UPDATE_INTERVAL_IN_MILLISECONDS = timeInterval
+            LocationUpdatesService.FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS = timeInterval/2
+        }
 
         return 0
     }

--- a/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
@@ -55,7 +55,7 @@ class LocationUpdatesService : Service() {
         internal const val EXTRA_LOCATION = "$PACKAGE_NAME.location"
         private const val EXTRA_STARTED_FROM_NOTIFICATION = "$PACKAGE_NAME.started_from_notification"
         var UPDATE_INTERVAL_IN_MILLISECONDS: Long = 1000
-        private val FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS = UPDATE_INTERVAL_IN_MILLISECONDS / 2
+        var FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS = UPDATE_INTERVAL_IN_MILLISECONDS / 2
         private const val NOTIFICATION_ID = 12345678
         private lateinit var broadcastReceiver: BroadcastReceiver
 


### PR DESCRIPTION
When you used `setConfiguration` to change the update interval, `FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS` was not updated accordingly. Therefore, Android's [`LocationRequest.setFastestInterval`](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest#public-locationrequest-setfastestinterval-long-fastestintervalmillis) was not set correctly.

This PR will also make `FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS` update when you use `setConfiguration`.

_FYI: I have already applied the same PR to my own repository: https://github.com/haukepribnow/background_location/pull/6_