### PR TITLE
Update action to publish to pub.dev

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,26 +1,22 @@
-name: Publish package to pub.dev
+# .github/workflows/publish.yml
+name: Publish to pub.dev
+
 on:
   push:
-    branches:   
-      - master
+    tags:
+    # must align with the tag-pattern configured on pub.dev, often just replace
+    #  with [0-9]+.[0-9]+.[0-9]+*
+    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: 'v'
+    # If you prefer tags like '1.2.3', without the 'v' prefix, then use:
+    # - '[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: ''
+    # If your repository contains multiple packages consider a pattern like:
+    # - 'my_package_name-v[0-9]+.[0-9]+.[0-9]+*'
+
+# Publish using the reusable workflow from dart-lang.
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    container:
-      image:  google/dart:latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Setup credentials
-      run: | 
-        mkdir -p ~/.pub-cache 
-        cat <<EOF > ~/.pub-cache/credentials.json
-        {
-          "accessToken":"${{ secrets.OAUTH_ACCESS_TOKEN }}",
-          "refreshToken":"${{ secrets.OAUTH_REFRESH_TOKEN }}",
-          "tokenEndpoint":"https://accounts.google.com/o/oauth2/token",
-          "scopes": [ "openid", "https://www.googleapis.com/auth/userinfo.email" ],
-          "expiration": 1570721159347
-        }
-        EOF
-    - name: Publish package
-      run: pub publish -f
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    # with:
+    #   working-directory: path/to/package/within/repository


### PR DESCRIPTION
It seems as though the recent merge of #183 should have triggered an automatic build/publish about 10 hours ago but it looks like [the workflow failed](https://github.com/Almoullim/background_location/actions/runs/5575009142).

This may help reduce instances of people reporting issues with things that are already fixed (if this is an issue)

It looks like the current action workflow is trying to use saved oauth tokens, when there may be a much [easier/better way to do this](https://dart.dev/tools/pub/automated-publishing#configuring-automated-publishing-from-github-actions-on-pubdev) as documented by flutter themselves.

This PR introduces the changes needed on the repo side for this to work. However, I am unable to make the changes on pub.dev as I don't have access to change the necessary settings

This is mainly a forward-looking fix, so prior versions between 1.8.1 (or whatevers currently on pub.dev) and the latest tagged version will probably need to be manually released.
