### PR TITLE
Fix the typo "opyright" to "copyright"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-opyright 2019 Ali Almoullim
+copyright 2019 Ali Almoullim
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
There was a typo in the LICENSE.txt. 
I've noticed it while adding it to my Acknowledgements.plist on my project.