### PR TITLE
Fix API issues stemming from Android 13/14 changes to location services

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ AndroidManifest.xml
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/> 
 ```
 <!-- TODO: Fix example -->

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
 
     <application>

--- a/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.annotation.NonNull
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 

--- a/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
@@ -8,6 +8,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ServiceInfo
 import android.os.*
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -180,7 +181,12 @@ class LocationUpdatesService : Service() {
     fun updateNotification() {
         if (!isStarted) {
             isStarted = true
-            startForeground(NOTIFICATION_ID, notification.build())
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                startForeground(NOTIFICATION_ID, notification.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
+            } else {
+                startForeground(NOTIFICATION_ID, notification.build())
+            }
+
         } else {
             val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.notify(NOTIFICATION_ID, notification.build())

--- a/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/LocationUpdatesService.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.*
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.android.gms.location.*
 import com.google.android.gms.location.LocationRequest
@@ -151,7 +152,12 @@ class LocationUpdatesService : Service() {
 
         val filter = IntentFilter()
         filter.addAction(STOP_SERVICE)
-        registerReceiver(broadcastReceiver, filter)
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(broadcastReceiver, filter, RECEIVER_EXPORTED)
+        } else {
+            registerReceiver(broadcastReceiver, filter)
+        }
+
 
         updateNotification() // to start the foreground service
     }


### PR DESCRIPTION
# What was the problem

On newer Android 13 and 14 Devices, the startLocationService() function causes a fatal crash, causing the app to exit and show the error mentioned in https://github.com/Almoullim/background_location/issues/200.

# How was it fixed

In the linked issue is a fork that already adresses 1 one of the issues caused by the version change, namely the extra flag for the reicever exported status, but it has some other issues that arise from Android 13 as well.

I fixed the `registerReceiver` call by making a API level check and depending on version code, call the function with or without the flag, in order to still stay compatible with API level 26 and below where the flag does not exist, inspired by [this](https://stackoverflow.com/a/77529595) StackOverflow answer.

```kotlin
if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
    registerReceiver(broadcastReceiver, filter, RECEIVER_EXPORTED)
} else {
    registerReceiver(broadcastReceiver, filter)
}
```

There was also another issue, caused be new permission requirements for the foreground service, where now need to more precisely define what kind of foreground service it is, which I added to the manifest.

```xml
<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
<uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
```

We also need to again change the function call signature of the foreground service to add the new permission type based on API level as before, inspired by [this](https://stackoverflow.com/a/76943772) StackOverflow answer.

```kotlin
if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
    startForeground(NOTIFICATION_ID, notification.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
} else {
    startForeground(NOTIFICATION_ID, notification.build())
}
```

