### PR TITLE
bump to 0.13.2 due to issue with .1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.13.2
+
+- Fixed issues with android namespaces
+- resolve flutter analyze lint errors and update flutter lint
+- Clarify permissions requirements earlier in the documentation [#226](https://github.com/Almoullim/background_location/pull/#226)
+
 ### 0.13.1
 
 - Fix License Typo [#201](https://github.com/Almoullim/background_location/pull/#201)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: background_location
 description: A Flutter plugin to get location updates in the background for both
   Android and iOS. Uses CoreLocation for iOS and FusedLocationProvider for
   Android.
-version: 0.13.1
+version: 0.13.2
 homepage: https://github.com/Almoullim/background_location
 repository: https://github.com/Almoullim/background_location
 


### PR DESCRIPTION
i accidentally tagged the commit on the feature branch for 0.13.1, rather than the commit from main.

While this means that the changelog is correct as far as what changed, it also means that some fixes that may impact people were missed.

This release should fix that